### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ There are 2 methods which starts `RubberLoaderView` animation: `RubberLoaderView
 
 Also you can set different interpolation functions by calling `RubberLoaderView.setInterpolator(TimeInterpolator interpolator)`. It's highly recommended to use following interpolators: `PulseInterpolator`, `PulseInverseInterpolator` and `LinearInterpolator`.
 
-##License
+## License
 
      Copyright 2015 greenfrvr
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
